### PR TITLE
Add NestJS backend with JWT auth and tasks CRUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+node_modules/
+Frontend/node_modules/
+backend/node_modules/
+dist/
+backend/dist/
+.env
+.env.*
+!*.example
+
+# TypeScript
+*.tsbuildinfo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+PORT=3000
+JWT_SECRET=define_un_secreto
+JWT_EXPIRES_IN=1d
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=tasksdb
+FRONTEND_ORIGIN=http://localhost:5173

--- a/backend/data-source.ts
+++ b/backend/data-source.ts
@@ -1,0 +1,20 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { config } from 'dotenv';
+import { join } from 'path';
+
+config();
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: [join(__dirname, 'src/**/*.entity{.ts,.js}')],
+  migrations: [join(__dirname, 'src/migrations/*{.ts,.js}')],
+  synchronize: false
+});
+
+export default AppDataSource;

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "tasks-backend",
+  "version": "1.0.0",
+  "private": true,
+  "description": "NestJS backend for tasks application",
+  "scripts": {
+    "build": "nest build",
+    "start": "node dist/main",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "migration:generate": "npm run typeorm -- -d data-source.ts migration:generate src/migrations/init",
+    "migration:run": "npm run typeorm -- -d data-source.ts migration:run",
+    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/config": "^3.2.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/jwt": "^10.2.0",
+    "@nestjs/mapped-types": "^2.0.2",
+    "@nestjs/passport": "^10.0.3",
+    "@nestjs/platform-express": "^10.0.0",
+    "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
+    "pg": "^8.11.5",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.2",
+    "@nestjs/schematics": "^10.1.1",
+    "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.2",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.4.8",
+    "@types/passport-jwt": "^3.0.9",
+    "eslint": "^8.52.0",
+    "rimraf": "^5.0.7",
+    "ts-loader": "^9.5.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
+import { TasksModule } from './tasks/tasks.module';
+import { User } from './users/user.entity';
+import { Task } from './tasks/task.entity';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        type: 'postgres',
+        host: configService.get<string>('DB_HOST', 'localhost'),
+        port: parseInt(configService.get<string>('DB_PORT', '5432'), 10),
+        username: configService.get<string>('DB_USER', 'postgres'),
+        password: configService.get<string>('DB_PASSWORD', 'postgres'),
+        database: configService.get<string>('DB_NAME', 'tasksdb'),
+        entities: [User, Task],
+        synchronize: false
+      })
+    }),
+    UsersModule,
+    AuthModule,
+    TasksModule
+  ]
+})
+export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+import { SafeUser } from '../users/users.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() registerDto: RegisterDto): Promise<SafeUser> {
+    return this.authService.register(registerDto);
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Body() loginDto: LoginDto): Promise<{ access_token: string }> {
+    return this.authService.login(loginDto);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { UsersModule } from '../users/users.module';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    ConfigModule,
+    UsersModule,
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET', 'define_un_secreto'),
+        signOptions: {
+          expiresIn: configService.get<string>('JWT_EXPIRES_IN', '1d')
+        }
+      })
+    })
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService]
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+import { UsersService, SafeUser } from '../users/users.service';
+import { User } from '../users/user.entity';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+
+interface JwtPayload {
+  sub: number;
+  email: string;
+}
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService
+  ) {}
+
+  async register(registerDto: RegisterDto): Promise<SafeUser> {
+    const user = await this.usersService.create(registerDto.email, registerDto.password);
+    return this.usersService.toSafeUser(user);
+  }
+
+  async validateUser(email: string, password: string): Promise<User> {
+    const user = await this.usersService.findByEmail(email);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const passwordValid = await bcrypt.compare(password, user.passwordHash);
+    if (!passwordValid) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    return user;
+  }
+
+  async login(loginDto: LoginDto): Promise<{ access_token: string }> {
+    const user = await this.validateUser(loginDto.email, loginDto.password);
+    const payload: JwtPayload = { sub: user.id, email: user.email };
+    const accessToken = await this.jwtService.signAsync(payload);
+    return { access_token: accessToken };
+  }
+}

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { Transform } from 'class-transformer';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  email!: string;
+
+  @IsString()
+  @MinLength(6)
+  password!: string;
+}

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,12 @@
+import { Transform } from 'class-transformer';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class RegisterDto {
+  @IsEmail()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  email!: string;
+
+  @IsString()
+  @MinLength(6)
+  password!: string;
+}

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/interfaces/authenticated-user.interface.ts
+++ b/backend/src/auth/interfaces/authenticated-user.interface.ts
@@ -1,0 +1,4 @@
+export interface AuthenticatedUser {
+  userId: number;
+  email: string;
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+
+interface JwtPayload {
+  sub: number;
+  email: string;
+}
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_SECRET', 'define_un_secreto')
+    });
+  }
+
+  validate(payload: JwtPayload): AuthenticatedUser {
+    return { userId: payload.sub, email: payload.email };
+  }
+}

--- a/backend/src/common/decorators/current-user.decorator.ts
+++ b/backend/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,10 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, context: ExecutionContext): AuthenticatedUser => {
+    const request = context.switchToHttp().getRequest<Request>();
+    return request.user as AuthenticatedUser;
+  }
+);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,29 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  const configService = app.get(ConfigService);
+  const frontendOrigin = configService.get<string>('FRONTEND_ORIGIN', 'http://localhost:5173');
+
+  app.enableCors({
+    origin: frontendOrigin,
+    credentials: true
+  });
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true
+    })
+  );
+
+  const port = configService.get<number>('PORT', 3000);
+  await app.listen(port);
+}
+
+void bootstrap();

--- a/backend/src/migrations/1710000000000-init.ts
+++ b/backend/src/migrations/1710000000000-init.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Init1710000000000 implements MigrationInterface {
+  name = 'Init1710000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "users" ("id" SERIAL NOT NULL, "email" character varying(255) NOT NULL, "password_hash" character varying(255) NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_users_id" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_users_email" ON "users" ("email")`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "tasks" ("id" SERIAL NOT NULL, "title" character varying(255) NOT NULL, "description" text, "done" boolean NOT NULL DEFAULT false, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "user_id" integer NOT NULL, CONSTRAINT "PK_tasks_id" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tasks" ADD CONSTRAINT "FK_tasks_user" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "tasks" DROP CONSTRAINT "FK_tasks_user"');
+    await queryRunner.query('DROP TABLE "tasks"');
+    await queryRunner.query('DROP INDEX "IDX_users_email"');
+    await queryRunner.query('DROP TABLE "users"');
+  }
+}

--- a/backend/src/tasks/dto/create-task.dto.ts
+++ b/backend/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateTaskDto {
+  @IsString()
+  @IsNotEmpty()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  })
+  description?: string;
+}

--- a/backend/src/tasks/dto/update-task.dto.ts
+++ b/backend/src/tasks/dto/update-task.dto.ts
@@ -1,0 +1,38 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { CreateTaskDto } from './create-task.dto';
+
+export class UpdateTaskDto extends PartialType(CreateTaskDto) {
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      if (value.toLowerCase() === 'true') {
+        return true;
+      }
+      if (value.toLowerCase() === 'false') {
+        return false;
+      }
+    }
+    return value;
+  })
+  done?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @Transform(({ value }) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '';
+  })
+  override description?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  override title?: string;
+}

--- a/backend/src/tasks/interfaces/task-response.interface.ts
+++ b/backend/src/tasks/interfaces/task-response.interface.ts
@@ -1,0 +1,6 @@
+export interface TaskResponse {
+  id: number;
+  title: string;
+  description?: string;
+  done: boolean;
+}

--- a/backend/src/tasks/task.entity.ts
+++ b/backend/src/tasks/task.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  JoinColumn
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+@Entity({ name: 'tasks' })
+export class Task {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: 'varchar', length: 255 })
+  title!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null = null;
+
+  @Column({ type: 'boolean', default: false })
+  done!: boolean;
+
+  @ManyToOne(() => User, (user) => user.tasks, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user!: User;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt!: Date;
+}

--- a/backend/src/tasks/tasks.controller.ts
+++ b/backend/src/tasks/tasks.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards
+} from '@nestjs/common';
+import { TasksService } from './tasks.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { TaskResponse } from './interfaces/task-response.interface';
+
+@Controller('tasks')
+@UseGuards(JwtAuthGuard)
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get()
+  async findAll(@CurrentUser() user: AuthenticatedUser): Promise<TaskResponse[]> {
+    return this.tasksService.findAllForUser(user.userId);
+  }
+
+  @Post()
+  async create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() createTaskDto: CreateTaskDto
+  ): Promise<TaskResponse> {
+    return this.tasksService.create(user.userId, createTaskDto);
+  }
+
+  @Get(':id')
+  async findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser
+  ): Promise<TaskResponse> {
+    return this.tasksService.findOneForUser(id, user.userId);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() updateTaskDto: UpdateTaskDto
+  ): Promise<TaskResponse> {
+    return this.tasksService.update(id, user.userId, updateTaskDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: AuthenticatedUser
+  ): Promise<void> {
+    await this.tasksService.remove(id, user.userId);
+  }
+}

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Task } from './task.entity';
+import { TasksService } from './tasks.service';
+import { TasksController } from './tasks.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Task])],
+  providers: [TasksService],
+  controllers: [TasksController]
+})
+export class TasksModule {}

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,108 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task } from './task.entity';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+import { TaskResponse } from './interfaces/task-response.interface';
+import { User } from '../users/user.entity';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly tasksRepository: Repository<Task>
+  ) {}
+
+  async create(userId: number, createTaskDto: CreateTaskDto): Promise<TaskResponse> {
+    const user = new User();
+    user.id = userId;
+
+    const task = this.tasksRepository.create({
+      title: createTaskDto.title,
+      description: createTaskDto.description ?? null,
+      done: false,
+      user
+    });
+
+    const savedTask = await this.tasksRepository.save(task);
+    return this.toResponse(savedTask);
+  }
+
+  async findAllForUser(userId: number): Promise<TaskResponse[]> {
+    const tasks = await this.tasksRepository.find({
+      where: { user: { id: userId } },
+      order: { id: 'ASC' }
+    });
+    return tasks.map((task) => this.toResponse(task));
+  }
+
+  async findOneForUser(id: number, userId: number): Promise<TaskResponse> {
+    const task = await this.tasksRepository.findOne({
+      where: { id, user: { id: userId } }
+    });
+
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    return this.toResponse(task);
+  }
+
+  async update(id: number, userId: number, updateTaskDto: UpdateTaskDto): Promise<TaskResponse> {
+    const task = await this.tasksRepository.findOne({
+      where: { id },
+      relations: { user: true }
+    });
+
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    if (task.user.id !== userId) {
+      throw new ForbiddenException('You cannot modify this task');
+    }
+
+    if (updateTaskDto.title !== undefined) {
+      task.title = updateTaskDto.title;
+    }
+
+    if (updateTaskDto.description !== undefined) {
+      const description = updateTaskDto.description;
+      task.description = description && description.length > 0 ? description : null;
+    }
+
+    if (updateTaskDto.done !== undefined) {
+      task.done = updateTaskDto.done;
+    }
+
+    const savedTask = await this.tasksRepository.save(task);
+    return this.toResponse(savedTask);
+  }
+
+  async remove(id: number, userId: number): Promise<void> {
+    const task = await this.tasksRepository.findOne({
+      where: { id },
+      relations: { user: true }
+    });
+
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+
+    if (task.user.id !== userId) {
+      throw new ForbiddenException('You cannot delete this task');
+    }
+
+    await this.tasksRepository.remove(task);
+  }
+
+  private toResponse(task: Task): TaskResponse {
+    return {
+      id: task.id,
+      title: task.title,
+      description: task.description ?? undefined,
+      done: task.done
+    };
+  }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  Index
+} from 'typeorm';
+import { Task } from '../tasks/task.entity';
+
+@Entity({ name: 'users' })
+export class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 255, unique: true })
+  email!: string;
+
+  @Column({ name: 'password_hash', type: 'varchar', length: 255 })
+  passwordHash!: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt!: Date;
+
+  @OneToMany(() => Task, (task) => task.user)
+  tasks!: Task[];
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './user.entity';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UsersService],
+  exports: [UsersService]
+})
+export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,0 +1,47 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { User } from './user.entity';
+
+export interface SafeUser {
+  id: number;
+  email: string;
+}
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>
+  ) {}
+
+  private normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+
+  async create(email: string, password: string): Promise<User> {
+    const normalizedEmail = this.normalizeEmail(email);
+    const existing = await this.usersRepository.findOne({ where: { email: normalizedEmail } });
+    if (existing) {
+      throw new ConflictException('Email already registered');
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = this.usersRepository.create({ email: normalizedEmail, passwordHash });
+    return this.usersRepository.save(user);
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const normalizedEmail = this.normalizeEmail(email);
+    return this.usersRepository.findOne({ where: { email: normalizedEmail } });
+  }
+
+  async findById(id: number): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { id } });
+  }
+
+  toSafeUser(user: User): SafeUser {
+    return { id: user.id, email: user.email };
+  }
+}

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "strictNullChecks": true,
+    "noImplicitAny": false,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*", "data-source.ts"],
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold a NestJS backend configured with ConfigModule, global validation, CORS, and TypeORM for PostgreSQL
- implement JWT-based authentication with user registration/login, bcrypt hashing, and guard/decorator helpers for accessing the authenticated user
- add task entities, DTO validation, and CRUD endpoints scoped to the current user along with an initial database migration and environment example

## Testing
- `npm install` *(fails: 403 Forbidden when downloading packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf67e1a0c08329bb41fe1aefd43de4